### PR TITLE
PR: readme example corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspired from [mdbook-admonish](https://tommilligan.github.io/mdbook-admonish/).
 
 ## Usage
 
-`#import " @preview/gentle-clues:0.4.0: info, success, warning, error`
+`#import "@preview/gentle-clues:0.4.0": info, success, warning, error`
 
 Overview of the predefined clues:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The follwing clues/admonitions (+ some aliases) are available at the moment. `ab
 But it is very easy to define your own. 
 
 ```typst 
+//When you import the package, include clue
+#import "@preview/gentle-clues:0.4.0": info, success, warning, error, clue
+
 //Define it
 #let ghost-admon(..args) = clue(
   title: "Buuuuh", 


### PR DESCRIPTION
First of all, thank you for this great package!

While I was setting up gentle-clues based on README, I ran into two issues:

1. The `import` command produced an error about missing a semicolon or linebreak.
2. Trying to define my own clue based on the provided example, I got the error, `unknown variable: clue`.

After a bit of trial and error, I found a solution for both issues. This PR reflects what I did.

Let me know if you have any thoughts. Thanks!